### PR TITLE
Tdx selftest misc patches

### DIFF
--- a/tools/testing/selftests/kvm/lib/x86_64/processor.c
+++ b/tools/testing/selftests/kvm/lib/x86_64/processor.c
@@ -636,7 +636,7 @@ struct kvm_vcpu *vm_arch_vcpu_add(struct kvm_vm *vm, uint32_t vcpu_id,
 	vcpu_regs_set(vcpu, &regs);
 
 	/* Setup the MP state */
-	mp_state.mp_state = 0;
+	mp_state.mp_state = KVM_MP_STATE_RUNNABLE;
 	vcpu_mp_state_set(vcpu, &mp_state);
 
 	return vcpu;
@@ -662,7 +662,7 @@ struct kvm_vcpu *vm_vcpu_add_tdx(struct kvm_vm *vm, uint32_t vcpu_id)
 	initialize_td_vcpu(vcpu);
 
 	/* Setup the MP state */
-	mp_state.mp_state = 0;
+	mp_state.mp_state = KVM_MP_STATE_RUNNABLE;
 	vcpu_mp_state_set(vcpu, &mp_state);
 
 	return vcpu;

--- a/tools/testing/selftests/kvm/lib/x86_64/tdx.h
+++ b/tools/testing/selftests/kvm/lib/x86_64/tdx.h
@@ -119,6 +119,7 @@ struct page_table {
 void add_td_memory(struct kvm_vm *vm, void *source_page,
 		   uint64_t gpa, int size);
 void finalize_td_memory(struct kvm_vm *vm);
+void get_tdx_capabilities(struct kvm_vm *vm);
 void initialize_td(struct kvm_vm *vm);
 void initialize_td_with_attributes(struct kvm_vm *vm, uint64_t attributes);
 void initialize_td_vcpu(struct kvm_vcpu *vcpu);

--- a/tools/testing/selftests/kvm/x86_64/tdx_vm_tests.c
+++ b/tools/testing/selftests/kvm/x86_64/tdx_vm_tests.c
@@ -197,6 +197,9 @@ void verify_td_lifecycle(void)
 	/* Create a TD VM with no memory.*/
 	vm = vm_create_tdx();
 
+	/* Get TDX capabilities */
+	get_tdx_capabilities(vm);
+
 	/* Allocate TD guest memory and initialize the TD.*/
 	initialize_td(vm);
 


### PR DESCRIPTION
This pull request includes the following three random patches for TDX selftest.

KVM: selftest: TDX: use symbolic value for KVM mp state
KVM: selftest: TDX: adjust CET and AMX for cpuid(eax=0xd, ecx=0x0)
KVM: selftest: tdx: call KVM_TDX_CAPABILITIES for test
